### PR TITLE
1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ For completeness, `determined#command` also creates `E` and `T` versions for ope
 - `:VTerm` - Like `:Term`, but in a vertical split . . . so this is identical to `:Term!` but is included for completeness.
 - `:STerm` - Synonymous with `:Term` but included for completeness.
 
+### Mappings
+
+Within a terminal window opened by `vim-determined`, `<C-r>` is mapped to rerun the original command. Hopefully, the symmetry is obvious. `<C-r>` is for "redo," but terminals are not modifiable, so I'm repurposing that keybinding to have specialized meaning.
+
 ## Contributing
 
 I always try to be open to suggestions, but I do still have opinions about what this should and should not be so . . . it never hurts to ask before investing a lot of time on a patch.

--- a/autoload/determined.vim
+++ b/autoload/determined.vim
@@ -15,4 +15,6 @@ function! determined#command(name, cmd, ...) abort
   endif
 
   exec command name 'call determined#command#run(' . string(cmd) . ', ' . string(args) . ', <bang>0, <q-mods>, <q-args>)'
+  exec command 'E' . name 'call determined#command#run(' . string(cmd) . ', ' . string(extend(copy(args), { 'curwin': 1 })) . ', <bang>0, <q-mods>, <q-args>)'
+  exec command 'T' . name 'tabnew | call determined#command#run(' . string(cmd) . ', ' . string(extend(copy(args), { 'curwin': 1 })) . ', <bang>0, <q-mods>, <q-args>)'
 endfunction

--- a/autoload/determined.vim
+++ b/autoload/determined.vim
@@ -14,5 +14,5 @@ function! determined#command(name, cmd, ...) abort
     let command .= ' -complete=' . args.complete
   endif
 
-  exec command name 'call determined#command#run(' . string(cmd) . ', ' . string(args) . ', <bang>0, <q-args>)'
+  exec command name 'call determined#command#run(' . string(cmd) . ', ' . string(args) . ', <bang>0, <q-mods>, <q-args>)'
 endfunction

--- a/autoload/determined.vim
+++ b/autoload/determined.vim
@@ -12,6 +12,7 @@ function! determined#command(name, cmd, ...) abort
 
   if has_key(args, 'complete')
     let command .= ' -complete=' . args.complete
+    unlet args.complete
   endif
 
   exec command name 'call determined#command#run(' . string(cmd) . ', ' . string(args) . ', <bang>0, <q-mods>, <q-args>)'

--- a/autoload/determined/command.vim
+++ b/autoload/determined/command.vim
@@ -89,6 +89,13 @@ function! determined#command#run(cmd, args, changeVert, mods, ...) abort
   " Execute the command, merging the options
   exec a:mods ' call term_start(' . shellescape(cmd, 1) . ', ' . string(opts) . ')'
 
+  let b:term_args = [a:cmd, a:args, a:changeVert, a:mods]
+  if a:0 > 0
+    let b:term_args += a:000
+  endif
+
+  nnoremap <buffer> <C-R> :call call('determined#command#run', b:term_args)<CR>
+
   "And return to the previous window
   if args.background
     wincmd p

--- a/autoload/determined/command.vim
+++ b/autoload/determined/command.vim
@@ -122,8 +122,35 @@ endfunction
 function! determined#command#reuse(bufnum, opts) abort
   let bufnum = a:bufnum
   let opts = a:opts
+  let num = bufwinnr(bufnum)
+  let name = bufname(bufnum)
 
-  exec bufwinnr(bufnum) . 'wincmd w'
+  if bufexists(name) && getbufinfo(name)[0].hidden
+    if opts.tabnew
+      let prefix = 'tab b'
+    elseif opts.curwin
+      let prefix = 'b'
+    elseif opts.vertical
+      let prefix = 'vert sb'
+    else
+      let prefix = 'sb'
+    endif
+
+    exec prefix bufnum
+  else
+    if num == -1
+      for i in range(1, tabpagenr('$'))
+        if index(tabpagebuflist(string(i)), bufnum) > -1
+          exec 'normal!' i . 'gt'
+          let num = bufwinnr(bufnum)
+          break
+        endif
+      endfor
+    endif
+
+    exec num . 'wincmd w'
+  endif
+
   let opts.curwin = 1
   if has_key(opts, 'term_cols')
     unlet opts.term_cols

--- a/autoload/determined/command.vim
+++ b/autoload/determined/command.vim
@@ -69,6 +69,23 @@ function! determined#command#run(cmd, args, changeVert, mods, ...) abort
     endif
   endif
 
+  " Auto size based on height/width ratios
+  if has_key(args, 'size') && args.size ==? 'auto' && !has_key(opts, 'curwin')
+    if has_key(opts, 'term_cols')
+      unlet opts.term_cols
+    endif
+    if has_key(opts, 'term_rows')
+      unlet opts.term_rows
+    endif
+    let widthRatio = winwidth(0) / str2float(&columns)
+    let heightRatio = winheight(0) / str2float(&lines)
+    if widthRatio > heightRatio
+      let opts.vertical = 1
+    else
+      let opts.vertical = 0
+    endif
+  endif
+
   " Execute the command, merging the options
   exec a:mods ' call term_start(' . shellescape(cmd, 1) . ', ' . string(opts) . ')'
 

--- a/autoload/determined/command.vim
+++ b/autoload/determined/command.vim
@@ -1,4 +1,4 @@
-function! determined#command#run(cmd, args, changeVert, ...) abort
+function! determined#command#run(cmd, args, changeVert, mods, ...) abort
   let cmd = a:cmd
   let args = a:args
   let moreCmd = len(a:0) ? a:1 : ''
@@ -48,7 +48,7 @@ function! determined#command#run(cmd, args, changeVert, ...) abort
   endif
 
   " Execute the command, merging the options
-  call term_start(cmd, opts)
+  exec a:mods ' call term_start(' . shellescape(cmd, 1) . ', ' . string(opts) . ')'
 
   "And return to the previous window
   if args.background

--- a/autoload/determined/command.vim
+++ b/autoload/determined/command.vim
@@ -4,7 +4,17 @@ function! determined#command#run(cmd, args, changeVert, mods, ...) abort
   let moreCmd = len(a:0) ? a:1 : ''
   let opts = {}
 
-  let defaults = { 'background': 1, 'vertical': 1, 'autoclose': 0, 'reuse': 0, 'expand': 0, 'term_args': {} }
+  let defaults = {
+    \   'background': 1,
+    \   'vertical': 1,
+    \   'autoclose': 0,
+    \   'reuse': 0,
+    \   'singleton': 0,
+    \   'expand': 0,
+    \   'tabnew': 0,
+    \   'curwin': 0,
+    \   'term_args': {}
+    \ }
   let args = extend(args, defaults, 'keep')
 
   if args.autoclose
@@ -18,6 +28,18 @@ function! determined#command#run(cmd, args, changeVert, mods, ...) abort
 
   if args.vertical
     let opts.vertical = args.vertical
+  endif
+
+  if args.tabnew || args.curwin
+    if has_key(opts, 'vertical')
+      unlet opts.vertical
+    endif
+
+    let opts.curwin = 1
+
+    if args.tabnew
+      tabnew
+    endif
   endif
 
   if has_key(args, 'size') || has_key(args, 'rows') || has_key(args, 'cols')

--- a/autoload/determined/command.vim
+++ b/autoload/determined/command.vim
@@ -58,7 +58,7 @@ function! determined#command#run(cmd, args, changeVert, mods, ...) abort
   let opts = extend(opts, args.term_args)
 
   if cmd =~? '%' && args.expand
-    let cmd = substitute(cmd, '%', expand('%'), 'g')
+    let cmd = substitute(cmd, '\(\(%\|#\d*\|<\w\+>\)\(:\w\)*\)', '\=expand(submatch(0))', 'g')
   endif
 
   let reuse = 0

--- a/autoload/determined/command.vim
+++ b/autoload/determined/command.vim
@@ -62,8 +62,8 @@ function! determined#command#run(cmd, args, changeVert, mods, ...) abort
   endif
 
   let reuse = 0
-  if args.reuse
-    let reuse = determined#command#findBufByCmd(cmd)
+  if args.reuse || args.singleton
+    let reuse = determined#command#findBufByCmd(args.singleton ? a:cmd : cmd)
     if reuse
       let opts = determined#command#reuse(reuse, opts)
     endif

--- a/autoload/determined/command.vim
+++ b/autoload/determined/command.vim
@@ -161,3 +161,20 @@ function! determined#command#reuse(bufnum, opts) abort
 
   return opts
 endfunction
+
+function! determined#command#close(force) abort
+  let terms = term_list()
+  for term in terms
+    let stopped = 0
+    let job = term_getjob(term)
+    let status = job_status(job)
+    if status == 'run' && a:force
+      let stopped = 1
+      call job_stop(job)
+    endif
+
+    if status != 'run' || stopped
+      exec 'bw' term
+    endif
+  endfor
+endfunction

--- a/autoload/determined/command.vim
+++ b/autoload/determined/command.vim
@@ -129,17 +129,18 @@ function! determined#command#calcSize(args) abort
     let size = float2nr(windowSize * size)
   endif
 
-  return type(size) == type('') ? size : string(size)
+  return type(size) == v:t_string ? size : string(size)
 endfunction
 
 function! determined#command#findBufByCmd(cmd) abort
   let cmd = a:cmd
-  for bufnum in range(1, bufnr('$'))
+  for bufnum in term_list()
     let name = bufname(bufnum)
     if name =~? '!' . cmd
       return bufnum
     endif
   endfor
+
   return 0
 endfunction
 

--- a/autoload/determined/command.vim
+++ b/autoload/determined/command.vim
@@ -87,14 +87,14 @@ function! determined#command#run(cmd, args, changeVert, mods, ...) abort
   endif
 
   " Execute the command, merging the options
-  exec a:mods ' call term_start(' . shellescape(cmd, 1) . ', ' . string(opts) . ')'
+  call determined#command#callTermStart(a:mods, cmd, opts)
 
-  let b:term_args = [a:cmd, a:args, a:changeVert, a:mods]
+  let b:term_args = [a:cmd]
   if a:0 > 0
     let b:term_args += a:000
   endif
 
-  nnoremap <buffer> <C-R> :call call('determined#command#run', b:term_args)<CR>
+  nnoremap <buffer> <C-R> :call determined#command#callTermStart('', join(b:term_args, ' '), { 'curwin': 1 })<CR>
 
   "And return to the previous window
   if args.background
@@ -202,4 +202,14 @@ function! determined#command#close(force) abort
       exec 'bw' term
     endif
   endfor
+endfunction
+
+function! determined#command#runGeneric(mods, args, opts) abort
+  call determined#command#callTermStart(a:mods, a:args, a:opts)
+  let b:term_args = a:args
+  nnoremap <buffer> <C-R> :call determined#command#callTermStart('', b:term_args, { 'curwin': 1 })<CR>
+endfunction
+
+function! determined#command#callTermStart(mods, args, opts) abort
+  exec a:mods 'call term_start(' . shellescape(a:args, 1) . ', ' . string(a:opts) . ')'
 endfunction

--- a/doc/determined.txt
+++ b/doc/determined.txt
@@ -2,7 +2,7 @@
 
 INTRODUCTION                                     *determined*
 
-A wrapper around vim 8's new term_start to make it friendlier and easier to
+A wrapper around vim 8's new |term_start| to make it friendlier and easier to
 use.
 
 CONTENTS                                         *determined-contents*
@@ -19,7 +19,7 @@ CONTENTS                                         *determined-contents*
 
 OVERVIEW                                         *determined-overview*
 
-Vim 8 added asynchronous terminal support via `term_start`, and it's _really
+Vim 8 added asynchronous terminal support via |term_start|, and it's _really
 neat_. Except it's a _pain_ to use. I basically have to do `:h term_start`
 every time I think I might want to use it. But it seems like it wasn't really
 intended to be used directly, since there's no command for it. You have to
@@ -28,7 +28,7 @@ invoke it with `:call term_start`. I could've made a simple command like
 plugin exposes the `determined#command` function, which you should call in
 your vim config setup (e.g. in vimrc). This function will create commands for
 you that wrap specific invocations of `:call term_start` to make it easy to
-use. For example, here are the current commands I'm creating in my setup via
+use. For example, here are some commands I'm creating in my setup via
 `determined#command`: >
 
   " Example:
@@ -117,15 +117,17 @@ INSTALLATION                                     *determined-installation*
 
 USAGE                                            *determined-usage*
 
-At the moment, vim-determined has only one function that you need to care
-about: |determined#command|.
+To create |term_start| wrappers at vim startup, use the |determined#command()|
+function. There is also a `:Term` (see |determined-:Term|) command for ad hoc
+terminal commands, and a `:TermClose` (see |deteremined-:TermClose|) command
+for closing previous terminal commands.
 
 FUNCTIONS                                        *determined-functions*
 
                                                  *determined#command()*
 determined#command(<name>, <cmd>, [args])
 
-Creates a command that wraps some command line tool in a call to `term_start`.
+Creates a command that wraps some command line tool in a call to |term_start|.
 
   `name` (string) The name of the command to create. 
   `cmd` (string)  A partial terminal command to execute when the created vim
@@ -153,7 +155,7 @@ working.
 `autoclose`                                        *determined#command-autoclose*
 
 This param sets `'term_finish': 'close'` in the options passed to
-`term_start`. Default `0`. This is useful if you need to install something or
+|term_start|. Default `0`. This is useful if you need to install something or
 run some other kind of build command of which you don't need to see the final
 output.
 
@@ -163,36 +165,62 @@ If the same command has been run previously, reuse the existing window instead
 of creating a new one. Default `0`. Useful for running tests or other
 recurring commands.
 
+`singleton`                                        *determined#command-singleton*
+
+Like `reuse` but ignores additional arguments. If you want all `grep`'s to
+happen in the same terminal window regardless of the query, use this option.
+
 `expand`                                           *determined#command-expand*
 
-Treat `%` specially and replace it with the current file name. Default `0`.
-Eventually, this will hopefully do _more_ expansion. For instance `grep -r foo
-%:h` to grep in the file's directory would be nice.
+Treat `%` (and `#`, `<cfile>`, etc.) specially and call |expand()| on it. Default `0`.
+|filename-modifiers| work here as well, so something like
+`:TermGrep foo %:h:h` would work as expected.
 
 `size`                                             *determined#command-size*
 
-The size of the terminal window. By default, `term_start` will use half the
+The size of the terminal window. By default, |term_start| will use half the
 vertical or horizontal space, and `vim-determined` keeps this default. You can
 pass a number (or string number) to specify the number of rows or columns,
 depending on the vertical flag (i.e. this becomes `term_rows` or `term_cols`).
 But you can also pass a percentage as a string (e.g. '40%') and
 `vim-determined` will figure out the number of rows or columns to use. You can
-also pass the special flags `small` (or `sm` or `quarter`) to make it 25%,
-`medium` (or `med` or `half`) to make it 50% (but instead you should probably
-just let it use the default), or `large` (or `lg`) to make it 75%.
+also pass the special flags `'small'` (or `'sm'` or `'quarter'`) to make it 25%,
+`'medium'` (or `'med'` or `'half'`) to make it 50% (but instead you should probably
+just let it use the default), or `'large'` (or `'lg'`) to make it 75%. Finally,
+there is a special value `'auto'` which will look at the window height and width
+ratios to determine for you whether a vertical or horizontal split would be
+more efficient. Passing `'auto'` is incompatible with passing `rows` and `cols`
+(see below). It will also cause `!` to be ignored. The one exception to this
+parameter is that if `curwin` is set, this option is ignored, as it will use
+the space of the current window regardless.
 
 `rows`                                             *determined#command-rows*
 `cols`                                             *determined#command-cols*
 
 The `size` parameter is not very granular, since you might want different
 sizes based on the window orientation. In that case, you can pass the same
-kinds of identifiers for `rows` and/or `cols` as you can for `size`.
+kinds of identifiers for `rows` and/or `cols` as you can for `size` (except for
+`'auto'` which would not make sense).
+
+`complete`                                         *determined#command-complete*
+
+Add custom completion. This maps basically one to one to the `-complete`
+option for commands (see |:command-complete|), so pass it exactly as you would
+there.
+
+`tabnew`                                           *determined#command-tabnew*
+
+Always run `cmd` in a new tab. Default `0`.
+
+`curwin`                                           *determined#command-curwin*
+
+Always run `cmd` in the current window. Default `0`.
 
 `term_args`                                        *determined#command-term_args*
 
 Finally, a catch all. This should be a dict, and anything you pass here will
-be added to the `term_start` options via `extend()`. Have a look at `:h
-term_start` for the various options supported.
+be added to the `term_start` options via `extend()`. See |term_start| for the
+various options supported.
 
 COMMANDS                                         *determined-commands*
 
@@ -210,6 +238,45 @@ You can invoke it in any of the following ways: >
   :Npm run custom-script
   :Npm ls
   :Npm install -D grunt grunt-contrib-copy grunt-contrib-concat
+
+|determined#command()| will also create `E` and `T` versions for opening the
+command in a new tab or in the current window (even though you can configure
+this per command via the args above. In the above example, the following
+commands are also created: >
+
+  :ENpm - Run the npm command in the current window
+  :TNpm - Run the npm command in a new tabpage
+<
+
+In additional, `vim-determined` includes the following built-in commands:
+
+`:TermClose[!]`                                    *determined-:TermClose*
+
+Close all open term windows where the job is not currently running. When
+<bang> is included, stop running jobs and close those terms too.
+
+`:Term[!]`                                         *determined-:Term*
+
+A generic wrapper for |term_start| for commands that you haven't created via
+|determined#command()|. For instance, `:Term find . -name somefile.ext` will
+run `find . -name somefile.ext` in a (by default) horizontal split. Use <bang>
+to open the command in a vertical split.
+
+`:ETerm`                                           *determined-:ETerm*
+
+Like `:Term`, but in the current window.
+
+`:TTerm`                                           *determined-:TTerm*
+
+Like `:Term`, but in a new tabpage.
+
+`:VTerm`                                           *determined-:VTerm*
+
+Synonymous with `:Term!`, but included for completeness.
+
+`:STerm`                                           *determined-:STerm*
+
+Synonymous with `:Term`, but included for completeness.
 
 ISSUES                                           *determined-issues*
 

--- a/doc/determined.txt
+++ b/doc/determined.txt
@@ -7,15 +7,16 @@ use.
 
 CONTENTS                                         *determined-contents*
 
-  1. Overview                                    |determined-overview|
-  2. Requirements                                |determined-requirements|
-  3. Installation                                |determined-installation|
-  4. Usage                                       |determined-usage|
-  5. Functions                                   |determined-functions|
-  6. Commands                                    |determined-commands|
-  7. Issues                                      |determined-issues|
-  8. Contributing                                |determined-contributing|
-  9. License                                     |determined-license|
+  1.  Overview                                    |determined-overview|
+  2.  Requirements                                |determined-requirements|
+  3.  Installation                                |determined-installation|
+  4.  Usage                                       |determined-usage|
+  5.  Functions                                   |determined-functions|
+  6.  Commands                                    |determined-commands|
+  7.  Mappings                                    |determined-mappings|
+  8.  Issues                                      |determined-issues|
+  9.  Contributing                                |determined-contributing|
+  10. License                                     |determined-license|
 
 OVERVIEW                                         *determined-overview*
 
@@ -277,6 +278,13 @@ Synonymous with `:Term!`, but included for completeness.
 `:STerm`                                           *determined-:STerm*
 
 Synonymous with `:Term`, but included for completeness.
+
+MAPPINGS                                         *determined-mappings*
+
+<C-r>                                            *determined-<C-r>*
+
+Within a terminal window created by `vim-determined` (but currently not if the
+job is still running), this will rerun the original command (e.g. "redo").
 
 ISSUES                                           *determined-issues*
 

--- a/plugin/determined.vim
+++ b/plugin/determined.vim
@@ -3,4 +3,10 @@ if exists('g:loaded_determined') || &cp | finish | endif
 let g:loaded_determined = 1
 
 let g:determined_VERSION = '1.1.1'
+
+command! -nargs=* -bang Term <mods> call term_start(<q-args>, { 'vertical': <bang>0 })
+command! -nargs=* ETerm call term_start(<q-args>, { 'curwin': 1 })
+command! -nargs=* TTerm tabnew | call term_start(<q-args>, { 'curwin': 1 })
+command! -nargs=* VTerm call term_start(<q-args>, { 'vertical': 1 })
+command! -nargs=* STerm call term_start(<q-args>)
 command! -nargs=0 -bang TermClose call determined#command#close(<bang>0)

--- a/plugin/determined.vim
+++ b/plugin/determined.vim
@@ -4,9 +4,9 @@ let g:loaded_determined = 1
 
 let g:determined_VERSION = '1.1.1'
 
-command! -nargs=* -bang Term <mods> call term_start(<q-args>, { 'vertical': <bang>0 })
-command! -nargs=* ETerm call term_start(<q-args>, { 'curwin': 1 })
-command! -nargs=* TTerm tabnew | call term_start(<q-args>, { 'curwin': 1 })
-command! -nargs=* VTerm call term_start(<q-args>, { 'vertical': 1 })
-command! -nargs=* STerm call term_start(<q-args>)
+command! -nargs=* -bang Term call determined#command#runGeneric(<q-mods>, <q-args>, { 'vertical': <bang>0 })
+command! -nargs=* ETerm call determined#command#runGeneric(<q-mods>, <q-args>, { 'curwin': 1 })
+command! -nargs=* TTerm tabnew | call determined#command#runGeneric(<q-mods>, <q-args>, { 'curwin': 1 })
+command! -nargs=* VTerm call determined#command#runGeneric(<q-mods>, <q-args>, { 'vertical': 1 })
+command! -nargs=* STerm call determined#command#runGeneric(<q-mods>, <q-args>)
 command! -nargs=0 -bang TermClose call determined#command#close(<bang>0)

--- a/plugin/determined.vim
+++ b/plugin/determined.vim
@@ -3,3 +3,4 @@ if exists('g:loaded_determined') || &cp | finish | endif
 let g:loaded_determined = 1
 
 let g:determined_VERSION = '1.1.1'
+command! -nargs=0 -bang TermClose call determined#command#close(<bang>0)


### PR DESCRIPTION
This PR

- supports passing `<mods>` (e.g. `:vert`, `:keepjumps`, `:tab`, etc.) to commands
- shellescapes arguments to commands
- adds support for running commands in new tabs and current windows
- fixes the reuse arg when the terminal window is hidden or in another tabpage
- adds a TermClose command
- adds a generic Term command
- supports better, more complete expansion (of e.g., `%`, `#`, `<cfile>`, etc.)
- adds a singleton option
- adds auto sizing/orienting
- adds a mapping to refresh the current term buffer
- includes other minor fixes and idiomatic code